### PR TITLE
Add JNCN to BIOS Crisis name table

### DIFF
--- a/Guides/BIOS/BIOS_CRISIS.md
+++ b/Guides/BIOS/BIOS_CRISIS.md
@@ -52,6 +52,7 @@ If your bios name is in this table, rename the just extracted rom to that name *
 |H1CN       | h1cn.bin      |
 |GKCN       | gkcn.bin      |
 |KWCN       | kwcn.bin      |
+|JNCN       | jncn.bin      |
 
 ## 5. Find the Crisis Name
  * Open The ROM File in UefiTool


### PR DESCRIPTION
This PR adds 'JNCN' type bios to BIOS Crisis name table