### PR TITLE
guide/bios_crisis: Add DZCN to BIOS Crisis name table

### DIFF
--- a/Guides/BIOS/BIOS_CRISIS.md
+++ b/Guides/BIOS/BIOS_CRISIS.md
@@ -53,6 +53,7 @@ If your bios name is in this table, rename the just extracted rom to that name *
 |GKCN       | gkcn.bin      |
 |KWCN       | kwcn.bin      |
 |JNCN       | jncn.bin      |
+|DZCN       | DZCrisis.bin  |
 
 ## 5. Find the Crisis Name
  * Open The ROM File in UefiTool


### PR DESCRIPTION
This PR adds DZCN BIOS to the Crisis name table.

My device: Lenovo Ideapad 3 (14ARE05, 81W3 Configuration)
BIOS CAP name: BIOS.CAP
BIOS Ver.: DZCN49WW.exe

As a side note, innoextract did not work for this installer. I worked around this by just running the installer, and letting it extract to specified folder.

Additionally, there was no mention of PcdSmmDxe anywhere, so what I did instead was open the BIOS.CAP file in HxD, and search for the 'crisis' string.

Below is a screenshot of the string:
<img width="867" alt="{873971F3-D7E0-46E3-97D2-5D1B9B8A6F8D}" src="https://github.com/user-attachments/assets/88383639-a4c9-4414-8c9a-48226dc6c058">
